### PR TITLE
Respect the Global Timeout in the Request

### DIFF
--- a/module/scrape.js
+++ b/module/scrape.js
@@ -90,7 +90,8 @@ const scrape = async ({ proxy = {},
             });
 
             await page.goto(url, {
-                waitUntil: ['load', 'networkidle0']
+                waitUntil: ['load', 'networkidle0'],
+                timeout: global.timeOut
             })
 
             if (mode == 'captcha') return


### PR DESCRIPTION
In the Puppeter if we don't insert a different timeout, by default the timeout is 30 seconds, so in the case who the timeout in the envs be greater then 30 we receive an timeout error from puppeter.