### PR TITLE
Env var to turn on headless

### DIFF
--- a/src/module/createBrowser.js
+++ b/src/module/createBrowser.js
@@ -8,7 +8,7 @@ async function createBrowser() {
         // console.log('Launching the browser...');
 
         const { browser } = await connect({
-            headless: false,
+            headless: process.env.HEADLESS == "true",
             turnstile: true,
             connectOption: { defaultViewport: null },
             disableXvfb: false,


### PR DESCRIPTION
The env var name for it is `HEADLESS`, must be set to `true` to put the browser headless.